### PR TITLE
Remove classmap autoload setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "autoload": {
         "psr-4": {
             "App\\": "src"
-        },
-        "classmap": ["src"]
+        }
     }
 }


### PR DESCRIPTION
# Changed log

- The `classmap` autoload setting is useless because all classes in `src` folder are under the `App` namespace. It's good enough to use the `psr-4` autoload setting in `composer.json` file.